### PR TITLE
Allows tracking logs to be sent to S3

### DIFF
--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -51,7 +51,7 @@
       when: SANDBOX_ENABLE_ECOMMERCE
     - notifier
     - analytics_api
-    - insights
+    # bower errors: - insights
     # not ready yet: - edx_notes_api
     - demo
     - oauth_client_setup

--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -41,6 +41,8 @@
     - role: mongo
       when: "'localhost' in EDXAPP_MONGO_HOSTS"
     - { role: 'rabbitmq', rabbitmq_ip: '127.0.0.1' }
+    - role: aws
+      when: EDXAPP_SETTINGS == 'aws'
     - { role: 'edxapp', celery_worker: True }
     - edxapp
     - role: ecommerce


### PR DESCRIPTION
Tracking logs are currently not being synced to S3, and so aren't available for analytics processing.

This PR adds the adds the `aws` role, which installs scripts and log rotation hooks which handle the transfer of rotated tracking log files to the configured S3 bucket.

Also removes the `insights` role, since it's giving bower errors, and we don't need it on `edxapp` instances.