### PR TITLE
Add analytics playbook with the analytics_api site included

### DIFF
--- a/playbooks/analytics_sandbox.yml
+++ b/playbooks/analytics_sandbox.yml
@@ -1,0 +1,27 @@
+- name: Deploy analytics related services (except the pipeline)
+  hosts: all
+  sudo: True
+  gather_facts: True
+  vars:
+    migrate_db: "yes"
+    disable_edx_services: false
+    ENABLE_DATADOG: False
+    ENABLE_SPLUNKFORWARDER: False
+    ENABLE_NEWRELIC: False
+  roles:
+    - aws
+    - security
+    - mysql
+    - edxlocal
+    - analytics_api
+    - role: nginx
+      nginx_sites:
+        - insights
+        - analytics_api
+      tags:
+        - nginx
+    - insights
+  tasks:
+    - name: 'Install required packages'
+      apt: name=libffi-dev state=present
+


### PR DESCRIPTION
This PR adds the playbook from the `duke-extend-dogwood` branch, except it has an additional `nginx_site`: `analytics_api`.

No additonal action is needed for HTTPS in this branch, because this version (unlike `duke-extend-dogwood`) includes the HTTPS config in the `analytics_api` site configuration already.


CC @pomegranited @bradenmacdonald 